### PR TITLE
doc: replace "gg-shield" with "ggshield"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-<a href="https://gitguardian.com/"><img src="https://cdn.jsdelivr.net/gh/gitguardian/gg-shield-action/doc/logo.svg"></a>
+<a href="https://gitguardian.com/"><img src="https://cdn.jsdelivr.net/gh/gitguardian/ggshield-action/doc/logo.svg"></a>
 
 ---
 
-# [GitGuardian Shield](https://github.com/GitGuardian/gg-shield) GitHub Action
+# [GitGuardian Shield](https://github.com/GitGuardian/ggshield) GitHub Action
 
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-v1-undefined.svg?logo=github&logoColor=white&style=for-the-badge)](https://github.com/marketplace/actions/gitguardian-shield-action)
 [![Docker Image Version (latest semver)](https://img.shields.io/docker/v/gitguardian/ggshield?color=1B2D55&sort=semver&style=for-the-badge&label=ggshield)](https://hub.docker.com/r/gitguardian/ggshield)
-[![License](https://img.shields.io/github/license/GitGuardian/gg-shield-action?color=%231B2D55&style=for-the-badge)](LICENSE)
-![GitHub stars](https://img.shields.io/github/stars/gitguardian/gg-shield-action?color=%231B2D55&style=for-the-badge)
+[![License](https://img.shields.io/github/license/GitGuardian/ggshield-action?color=%231B2D55&style=for-the-badge)](LICENSE)
+![GitHub stars](https://img.shields.io/github/stars/gitguardian/ggshield-action?color=%231B2D55&style=for-the-badge)
 
-Find exposed credentials in your commits using [**GitGuardian shield**](https://github.com/GitGuardian/gg-shield).
+Find exposed credentials in your commits using [**GitGuardian shield**](https://github.com/GitGuardian/ggshield).
 
-The **GitGuardian shield** (gg-shield) is a CLI application that runs in your local environment
+The **GitGuardian shield** (ggshield) is a CLI application that runs in your local environment
 or in a CI environment to help you detect more than 200 types of secrets, as well as other potential security vulnerabilities or policy breaks.
 
 **GitGuardian shield** uses our [public API](https://api.gitguardian.com/doc) through [py-gitguardian](https://github.com/GitGuardian/py-gitguardian) to scan your files and detect potential secrets or issues in your code. **The `/v1/scan` endpoint of the [public API](https://api.gitguardian.com/doc) is stateless. We will not store any files you are sending or any secrets we have detected**.
@@ -27,7 +27,7 @@ or in a CI environment to help you detect more than 200 types of secrets, as wel
 
 ## Usage
 
-Add a new job to your GitHub workflow using the `GitGuardian/gg-shield-action` action.
+Add a new job to your GitHub workflow using the `GitGuardian/ggshield-action` action.
 
 ```yaml
 name: GitGuardian scan
@@ -44,7 +44,7 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan
-        uses: GitGuardian/gg-shield-action@master
+        uses: GitGuardian/ggshield-action@master
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
@@ -90,7 +90,7 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan
-        uses: GitGuardian/gg-shield-action@master
+        uses: GitGuardian/ggshield-action@master
         with:
           args: -v --all-policies
         env:
@@ -103,15 +103,15 @@ jobs:
 
 ## Examples of GitGuardian scanning
 
-![Scan output example](https://cdn.statically.io/gh/GitGuardian/gg-shield-action/51c86f8a/doc/example_output.png)
+![Scan output example](https://cdn.statically.io/gh/GitGuardian/ggshield-action/51c86f8a/doc/example_output.png)
 
 This a sample scan result from **GitGuardian shield**.
 
 If the secret detected has been revoked and you do not wish to rewrite git history, you can use a value of the policy break (for example: the value of `|_password_|`) or the ignore SHA displayed in your `.gitguardian.yaml` under `matches-ignore`.
 
-An example configuration file is available [here](https://github.com/GitGuardian/gg-shield/blob/main/.gitguardian.example.yml).
+An example configuration file is available [here](https://github.com/GitGuardian/ggshield/blob/main/.gitguardian.example.yml).
 
-![Status example](https://cdn.statically.io/gh/GitGuardian/gg-shield-action/51c86f8a/doc/status.png)
+![Status example](https://cdn.statically.io/gh/GitGuardian/ggshield-action/51c86f8a/doc/status.png)
 
 If there are secret leaks or other security issues in your commit your workflow will be marked as failed.
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: GitGuardian <support@gitguardian.com>
 inputs:
   args:
     description: |
-      Arguments to be passed to gg-shield scan
+      Arguments to be passed to ggshield secret scan
       Options:
         --show-secrets  Show secrets in plaintext instead of hiding them.
         --exit-zero     Always return a 0 (non-error) status code, even if issues


### PR DESCRIPTION
Replace all "gg-shield" with "ggshield". This is more consistent.

I verified all modified URLs still work.