### PR TITLE
feat(action): # pin ggshield image to 1.14.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ branding:
   color: "blue"
 runs:
   using: "docker"
-  image: "docker://gitguardian/ggshield:latest"
+  image: "docker://gitguardian/ggshield:v1.14.4"
   entrypoint: "/app/docker/actions-secret-entrypoint.sh"
   args:
     - ${{ inputs.args }}


### PR DESCRIPTION
We currently use the latest ggshield Docker image. We also use the entrypoint defined in this Docker image.  
This introduces a dependency between [ggshield](https://github.com/GitGuardian/ggshield) and [ggshield-action](https://github.com/GitGuardian/ggshield-action).  

Hence, we pin the Docker image used in the action yaml to prevent any future breaks.   

This action was tested [here](https://github.com/pierrelalanne/ggshield-actions-tests/actions/runs/4261629884/jobs/7416256235).

**Note :** To ensure users can still access the latest release of ggshield in their actions, we will synchronize the release of ggshield with the release of this repository.