### PR TITLE
Prepare project for semi-pinned tags for major version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,13 +3,14 @@ name: Application Release
 on:
   push:
     tags:
-      - "v*"
+      # Trigger workflow on push events for version tags (e.g. v1.28.0) but not for major version tag (e.g. v1)
+      - "v*.*"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Find exposed credentials in your commits using [**GitGuardian shield**](https://github.com/GitGuardian/ggshield).
 
 The **GitGuardian shield** (ggshield) is a CLI application that runs in your local environment
-or in a CI environment to help you detect more than 200 types of secrets, as well as other potential security vulnerabilities or policy breaks.
+or in a CI environment to help you detect more than 400 types of secrets, as well as other potential security vulnerabilities or policy breaks.
 
 **GitGuardian shield** uses our [public API](https://api.gitguardian.com/doc) through [py-gitguardian](https://github.com/GitGuardian/py-gitguardian) to scan your files and detect potential secrets or issues in your code. **The `/v1/scan` endpoint of the [public API](https://api.gitguardian.com/doc) is stateless. We will not store any files you are sending or any secrets we have detected**.
 
@@ -44,7 +44,7 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1.28.0
+        uses: GitGuardian/ggshield-action@v1
         env:
           GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
           GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history so multiple commits can be scanned
       - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1.28.0
+        uses: GitGuardian/ggshield-action@v1
         with:
           args: -v --ignore-known-secrets
         env:


### PR DESCRIPTION
This MR aims to prepare this project for semi-pinned tags for major versions. 
Tags will be created and updated in ggshield-tools release script. 

This MR needs to be merged first.
Works with MR#22 on ggshield-tools. Needs to be merged first. 